### PR TITLE
tests: test Node.js 8 and 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ cache:
   directories:
     - "$HOME/.npm"
 node_js:
-  - 9
+  - 8
+  - 10
 script:
   # https://github.com/lerna/lerna/issues/1457
   - npm run bootstrap -- --no-ci


### PR DESCRIPTION
Node.js 9 already reached its EOL. Odd releases / release branches are not LTS and not stable.